### PR TITLE
feat: 장소 추가 및 공유 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,8 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	implementation 'org.springframework.boot:spring-boot-starter-websocket'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/goormcoder/ieum/config/WebSocketConfig.java
+++ b/src/main/java/com/goormcoder/ieum/config/WebSocketConfig.java
@@ -1,0 +1,23 @@
+package com.goormcoder.ieum.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry config) {
+        config.enableSimpleBroker("/sub");
+        config.setApplicationDestinationPrefixes("/pub");
+    }
+
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        registry.addEndpoint("/ws").setAllowedOrigins("*");
+    }
+}

--- a/src/main/java/com/goormcoder/ieum/controller/PlaceController.java
+++ b/src/main/java/com/goormcoder/ieum/controller/PlaceController.java
@@ -32,11 +32,6 @@ public class PlaceController {
         return place.map(ResponseEntity::ok).orElseGet(() -> ResponseEntity.notFound().build());
     }
 
-    @PostMapping("/{planId}")
-    public Place createPlace(@PathVariable Long planId, @RequestBody Place place) {
-        return placeService.createPlace(planId, place);
-    }
-
     @PutMapping("/{id}")
     public ResponseEntity<Place> updatePlace(@PathVariable Long id, @RequestBody Place updatedPlace) {
         return ResponseEntity.ok(placeService.updatePlace(id, updatedPlace));

--- a/src/main/java/com/goormcoder/ieum/controller/PlaceController.java
+++ b/src/main/java/com/goormcoder/ieum/controller/PlaceController.java
@@ -28,8 +28,9 @@ public class PlaceController {
 
     @GetMapping("/{id}")
     public ResponseEntity<Place> getPlaceById(@PathVariable Long id) {
-        Optional<Place> place = placeService.findPlaceById(id);
-        return place.map(ResponseEntity::ok).orElseGet(() -> ResponseEntity.notFound().build());
+//        Optional<Place> place = placeService.findPlaceById(id);
+//        return place.map(ResponseEntity::ok).orElseGet(() -> ResponseEntity.notFound().build());
+        return ResponseEntity.noContent().build();
     }
 
     @PutMapping("/{id}")

--- a/src/main/java/com/goormcoder/ieum/controller/PlanController.java
+++ b/src/main/java/com/goormcoder/ieum/controller/PlanController.java
@@ -1,14 +1,12 @@
 package com.goormcoder.ieum.controller;
 
 
-import com.goormcoder.ieum.domain.Invite;
-import com.goormcoder.ieum.domain.enumeration.InviteAcceptance;
 import com.goormcoder.ieum.dto.request.PlaceCreateDto;
+import com.goormcoder.ieum.dto.request.PlaceShareDto;
 import com.goormcoder.ieum.dto.request.PlanCreateDto;
-import com.goormcoder.ieum.dto.request.PlanMemberCreateDto;
 import com.goormcoder.ieum.dto.response.DestinationFindDto;
+import com.goormcoder.ieum.dto.response.PlaceFindDto;
 import com.goormcoder.ieum.service.PlaceService;
-import com.goormcoder.ieum.service.PlanMemberService;
 import com.goormcoder.ieum.service.PlanService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -16,6 +14,9 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.messaging.simp.SimpMessageSendingOperations;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 
@@ -31,6 +32,8 @@ public class PlanController {
     private final PlanService planService;
     private final PlaceService placeService;
 
+    private final SimpMessageSendingOperations messagingTemplate;
+
     @GetMapping
     @Operation(summary = "여행지 목록 조회", description = "여행지 목록을 조회합니다.")
     public ResponseEntity<List<DestinationFindDto>> getAllDestination() {
@@ -40,7 +43,7 @@ public class PlanController {
     @PostMapping
     @Operation(summary = "일정 생성", description = "일정을 생성합니다. 이동수단(vehicle) 유형 - PUBLIC_TRANSPORTATION 또는 OWN_CAR")
     public ResponseEntity<String> createPlan(@Valid @RequestBody PlanCreateDto planCreateDto) {
-        UUID memberId = UUID.fromString(SecurityContextHolder.getContext().getAuthentication().getPrincipal().toString());
+        UUID memberId = getMemberId();
         planService.createPlan(planCreateDto, memberId);
         return ResponseEntity.status(HttpStatus.OK).body("일정이 생성되었습니다.");
     }
@@ -48,9 +51,20 @@ public class PlanController {
     @PostMapping("/pre-place")
     @Operation(summary = "장소 추가", description = "사용자별로 방문하고 싶은 장소를 추가합니다. 카테고리 유형 - 1(명소) 또는 2(식당/카페) 또는 3(숙소)")
     public ResponseEntity<String> createPlace(@RequestBody PlaceCreateDto placeCreateDto) {
-        UUID memberId = UUID.fromString(SecurityContextHolder.getContext().getAuthentication().getPrincipal().toString());
+        UUID memberId = getMemberId();
         placeService.createPlace(memberId, placeCreateDto);
         return ResponseEntity.status(HttpStatus.OK).body("장소가 추가되었습니다.");
+    }
+
+    @MessageMapping("/share-place")
+    public void addPlace(@Payload PlaceShareDto placeShareDto) {
+        // UUID memberId = getMemberId(); - 검증 추가 예정
+        PlaceFindDto placeFindDto = placeService.sharePlace(placeShareDto);
+        messagingTemplate.convertAndSend("/sub/plans/" + placeFindDto.planId(), placeFindDto);
+    }
+
+    private UUID getMemberId() {
+        return UUID.fromString(SecurityContextHolder.getContext().getAuthentication().getPrincipal().toString());
     }
 
 }

--- a/src/main/java/com/goormcoder/ieum/controller/PlanController.java
+++ b/src/main/java/com/goormcoder/ieum/controller/PlanController.java
@@ -6,7 +6,6 @@ import com.goormcoder.ieum.dto.request.PlaceShareDto;
 import com.goormcoder.ieum.dto.request.PlanCreateDto;
 import com.goormcoder.ieum.dto.response.DestinationFindDto;
 import com.goormcoder.ieum.dto.response.PlaceFindDto;
-import com.goormcoder.ieum.dto.response.PlanFindDto;
 import com.goormcoder.ieum.service.PlaceService;
 import com.goormcoder.ieum.service.PlanService;
 import io.swagger.v3.oas.annotations.Operation;

--- a/src/main/java/com/goormcoder/ieum/controller/PlanController.java
+++ b/src/main/java/com/goormcoder/ieum/controller/PlanController.java
@@ -6,6 +6,7 @@ import com.goormcoder.ieum.dto.request.PlaceShareDto;
 import com.goormcoder.ieum.dto.request.PlanCreateDto;
 import com.goormcoder.ieum.dto.response.DestinationFindDto;
 import com.goormcoder.ieum.dto.response.PlaceFindDto;
+import com.goormcoder.ieum.dto.response.PlanFindDto;
 import com.goormcoder.ieum.service.PlaceService;
 import com.goormcoder.ieum.service.PlanService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -60,7 +61,7 @@ public class PlanController {
     public void addPlace(@Payload PlaceShareDto placeShareDto) {
         // UUID memberId = getMemberId(); - 검증 추가 예정
         PlaceFindDto placeFindDto = placeService.sharePlace(placeShareDto);
-        messagingTemplate.convertAndSend("/sub/plans/" + placeFindDto.planId(), placeFindDto);
+        messagingTemplate.convertAndSend("/sub/plans/" + placeShareDto.planId(), placeFindDto);
     }
 
     private UUID getMemberId() {

--- a/src/main/java/com/goormcoder/ieum/controller/PlanController.java
+++ b/src/main/java/com/goormcoder/ieum/controller/PlanController.java
@@ -3,9 +3,11 @@ package com.goormcoder.ieum.controller;
 
 import com.goormcoder.ieum.domain.Invite;
 import com.goormcoder.ieum.domain.enumeration.InviteAcceptance;
+import com.goormcoder.ieum.dto.request.PlaceCreateDto;
 import com.goormcoder.ieum.dto.request.PlanCreateDto;
 import com.goormcoder.ieum.dto.request.PlanMemberCreateDto;
 import com.goormcoder.ieum.dto.response.DestinationFindDto;
+import com.goormcoder.ieum.service.PlaceService;
 import com.goormcoder.ieum.service.PlanMemberService;
 import com.goormcoder.ieum.service.PlanService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -27,6 +29,7 @@ import java.util.UUID;
 public class PlanController {
 
     private final PlanService planService;
+    private final PlaceService placeService;
 
     @GetMapping
     @Operation(summary = "여행지 목록 조회", description = "여행지 목록을 조회합니다.")
@@ -42,6 +45,12 @@ public class PlanController {
         return ResponseEntity.status(HttpStatus.OK).body("일정이 생성되었습니다.");
     }
 
-
+    @PostMapping("/pre-place")
+    @Operation(summary = "장소 추가", description = "사용자별로 방문하고 싶은 장소를 추가합니다. 카테고리 유형 - 1(명소) 또는 2(식당/카페) 또는 3(숙소)")
+    public ResponseEntity<String> createPlace(@RequestBody PlaceCreateDto placeCreateDto) {
+        UUID memberId = UUID.fromString(SecurityContextHolder.getContext().getAuthentication().getPrincipal().toString());
+        placeService.createPlace(memberId, placeCreateDto);
+        return ResponseEntity.status(HttpStatus.OK).body("장소가 추가되었습니다.");
+    }
 
 }

--- a/src/main/java/com/goormcoder/ieum/domain/Place.java
+++ b/src/main/java/com/goormcoder/ieum/domain/Place.java
@@ -1,24 +1,15 @@
 package com.goormcoder.ieum.domain;
 
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import lombok.*;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @Entity
 @Getter
-@Table(name = "t_place")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @EqualsAndHashCode
-@EntityListeners(AuditingEntityListener.class)
-public class Place {
+public class Place extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -29,38 +20,59 @@ public class Place {
     @JoinColumn(name = "plan_id", nullable = false)
     private Plan plan;
 
-    @Column(name = "place_order", nullable = false)
-    private int placeOrder;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
 
-    @Column(name = "place_day", nullable = false)
-    private LocalDate placeDay;
+    @Column
+    private LocalDateTime startedAt;
+
+    @Column
+    private LocalDateTime endedAt;
 
     @Column(name = "place_name", nullable = false)
     private String placeName;
 
     @Column(name = "place_location", nullable = false)
-    private String placeLocation;
+    private String address;
 
-    @CreatedDate
-    @Column(name = "created_at", updatable = false)
-    private LocalDateTime createdAt;
+    private LocalDateTime activatedAt;
 
-    @Column(name = "deleted_at")
-    private LocalDateTime deletedAt;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "category_id", nullable = false)
+    private Category category;
 
     @Builder
-    public Place(Plan plan, int placeOrder, LocalDate placeDay, String placeName, String placeLocation) {
+    private Place(Plan plan, Member member, LocalDateTime startedAt, LocalDateTime endedAt,
+                  String placeName, String address, Category category) {
         this.plan = plan;
-        this.placeOrder = placeOrder;
-        this.placeDay = placeDay;
+        this.member = member;
+        this.startedAt = startedAt;
+        this.endedAt = endedAt;
         this.placeName = placeName;
-        this.placeLocation = placeLocation;
+        this.address = address;
+        this.category = category;
     }
 
-    public void setDeletedAt(LocalDateTime deletedAt) {
-        this.deletedAt = deletedAt;
+    public static Place of(Plan plan, Member member, LocalDateTime startedAt, LocalDateTime endedAt,
+                           String placeName, String address, Category category) {
+        return Place.builder()
+                .plan(plan)
+                .member(member)
+                .startedAt(startedAt)
+                .endedAt(endedAt)
+                .placeName(placeName)
+                .address(address)
+                .category(category)
+                .build();
     }
 
-    public void setId(Long id) {
+    public void marksActivatedAt() {
+        this.activatedAt = LocalDateTime.now();
     }
+
+    public boolean isActive() {
+        return this.activatedAt != null;
+    }
+
 }

--- a/src/main/java/com/goormcoder/ieum/domain/Plan.java
+++ b/src/main/java/com/goormcoder/ieum/domain/Plan.java
@@ -39,7 +39,7 @@ public class Plan extends BaseEntity {
     @OneToMany(mappedBy = "plan", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Accommodation> accommodations;
 
-    @OneToMany(mappedBy = "plan", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "plan", cascade = {CascadeType.PERSIST, CascadeType.MERGE})
     private List<Place> places;
 
     @Builder
@@ -61,6 +61,10 @@ public class Plan extends BaseEntity {
 
     public void addPlanMember(PlanMember planMember) {
         planMembers.add(planMember);
+    }
+
+    public void addPlace(Place place) {
+        places.add(place);
     }
 
 }

--- a/src/main/java/com/goormcoder/ieum/dto/request/PlaceCreateDto.java
+++ b/src/main/java/com/goormcoder/ieum/dto/request/PlaceCreateDto.java
@@ -1,10 +1,5 @@
 package com.goormcoder.ieum.dto.request;
 
-import com.goormcoder.ieum.domain.Category;
-import com.goormcoder.ieum.domain.enumeration.CategoryType;
-
-import java.time.LocalDateTime;
-
 public record PlaceCreateDto(
 
         Long planId,

--- a/src/main/java/com/goormcoder/ieum/dto/request/PlaceCreateDto.java
+++ b/src/main/java/com/goormcoder/ieum/dto/request/PlaceCreateDto.java
@@ -1,0 +1,16 @@
+package com.goormcoder.ieum.dto.request;
+
+import com.goormcoder.ieum.domain.Category;
+import com.goormcoder.ieum.domain.enumeration.CategoryType;
+
+import java.time.LocalDateTime;
+
+public record PlaceCreateDto(
+
+        Long planId,
+        String placeName,
+        String address,
+        Long categoryId
+
+) {
+}

--- a/src/main/java/com/goormcoder/ieum/dto/request/PlaceShareDto.java
+++ b/src/main/java/com/goormcoder/ieum/dto/request/PlaceShareDto.java
@@ -2,6 +2,7 @@ package com.goormcoder.ieum.dto.request;
 
 public record PlaceShareDto(
 
+        Long planId,
         Long placeId
 
 ) {

--- a/src/main/java/com/goormcoder/ieum/dto/request/PlaceShareDto.java
+++ b/src/main/java/com/goormcoder/ieum/dto/request/PlaceShareDto.java
@@ -1,0 +1,8 @@
+package com.goormcoder.ieum.dto.request;
+
+public record PlaceShareDto(
+
+        Long placeId
+
+) {
+}

--- a/src/main/java/com/goormcoder/ieum/dto/response/PlaceFindDto.java
+++ b/src/main/java/com/goormcoder/ieum/dto/response/PlaceFindDto.java
@@ -1,12 +1,21 @@
 package com.goormcoder.ieum.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.goormcoder.ieum.domain.Place;
+
+import java.time.LocalDateTime;
 
 public record PlaceFindDto(
 
-        Long planId,
         String placeName,
         String address,
+
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        LocalDateTime startedAt,
+
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        LocalDateTime endedAt,
+
         Long categoryId,
         String memberLoginId
 
@@ -14,12 +23,12 @@ public record PlaceFindDto(
 
     public static PlaceFindDto of(Place place) {
         return new PlaceFindDto(
-                place.getPlan().getId(),
                 place.getPlaceName(),
                 place.getAddress(),
+                place.getStartedAt(),
+                place.getEndedAt(),
                 place.getCategory().getId(),
-                place.getMember().getLoginId()
-                );
+                place.getMember().getLoginId());
     }
 
 }

--- a/src/main/java/com/goormcoder/ieum/dto/response/PlaceFindDto.java
+++ b/src/main/java/com/goormcoder/ieum/dto/response/PlaceFindDto.java
@@ -1,0 +1,25 @@
+package com.goormcoder.ieum.dto.response;
+
+import com.goormcoder.ieum.domain.Place;
+
+public record PlaceFindDto(
+
+        Long planId,
+        String placeName,
+        String address,
+        Long categoryId,
+        String memberLoginId
+
+) {
+
+    public static PlaceFindDto of(Place place) {
+        return new PlaceFindDto(
+                place.getPlan().getId(),
+                place.getPlaceName(),
+                place.getAddress(),
+                place.getCategory().getId(),
+                place.getMember().getLoginId()
+                );
+    }
+
+}

--- a/src/main/java/com/goormcoder/ieum/exception/ErrorMessages.java
+++ b/src/main/java/com/goormcoder/ieum/exception/ErrorMessages.java
@@ -12,6 +12,7 @@ public enum ErrorMessages {
     DESTINATION_NOT_FOUND("해당하는 여행지가 존재하지 않습니다."),
     INVITE_NOT_FOUND("존재하지 않는 초대입니다."),
     CATEGORY_NOT_FOUND("해당하는 카테고리가 존재하지 않습니다."),
+    PLACE_NOT_FOUND("해당하는 장소가 존재하지 않습니다."),
 
     // 409 CONFLICT
     INVITE_REQUEST_CONFLICT("이미 초대한 멤버입니다."),

--- a/src/main/java/com/goormcoder/ieum/exception/ErrorMessages.java
+++ b/src/main/java/com/goormcoder/ieum/exception/ErrorMessages.java
@@ -13,6 +13,7 @@ public enum ErrorMessages {
     INVITE_NOT_FOUND("존재하지 않는 초대입니다."),
     CATEGORY_NOT_FOUND("해당하는 카테고리가 존재하지 않습니다."),
     PLACE_NOT_FOUND("해당하는 장소가 존재하지 않습니다."),
+    PLAN_NOT_FOUND("해당하는 일정이 존재하지 않습니다."),
 
     // 409 CONFLICT
     INVITE_REQUEST_CONFLICT("이미 초대한 멤버입니다."),

--- a/src/main/java/com/goormcoder/ieum/exception/ErrorMessages.java
+++ b/src/main/java/com/goormcoder/ieum/exception/ErrorMessages.java
@@ -11,6 +11,7 @@ public enum ErrorMessages {
     MEMBER_NOT_FOUND("해당하는 일정이 존재하지 않습니다."),
     DESTINATION_NOT_FOUND("해당하는 여행지가 존재하지 않습니다."),
     INVITE_NOT_FOUND("존재하지 않는 초대입니다."),
+    CATEGORY_NOT_FOUND("해당하는 카테고리가 존재하지 않습니다."),
 
     // 409 CONFLICT
     INVITE_REQUEST_CONFLICT("이미 초대한 멤버입니다."),

--- a/src/main/java/com/goormcoder/ieum/service/PlaceService.java
+++ b/src/main/java/com/goormcoder/ieum/service/PlaceService.java
@@ -36,7 +36,9 @@ public class PlaceService {
         Member member = memberService.findById(memberId);
         Plan plan = planService.findByPlanId(dto.planId());
         Category category = findByCategoryId(dto.categoryId());
-        Place place = placeRepository.save(Place.of(plan, member, null, null, dto.placeName(), dto.address(), category));
+        Place place = Place.of(plan, member, null, null, dto.placeName(), dto.address(), category);
+        plan.addPlace(place);
+        planRepository.save(plan);
     }
 
     @Transactional
@@ -44,9 +46,12 @@ public class PlaceService {
         // memberService.findById(memberId); - 검증 추가 예정
         Place place = findPlaceById(dto.placeId());
         place.marksActivatedAt();
-        Place savedPlace = placeRepository.save(place);
 
-        return PlaceFindDto.of(savedPlace);
+        Plan plan = planService.findByPlanId(dto.planId());
+        plan.addPlace(place);
+        planRepository.save(plan);
+
+        return PlaceFindDto.of(place);
     }
 
     public List<Place> findAllPlaces() {

--- a/src/main/java/com/goormcoder/ieum/service/PlaceService.java
+++ b/src/main/java/com/goormcoder/ieum/service/PlaceService.java
@@ -6,6 +6,8 @@ import com.goormcoder.ieum.domain.Member;
 import com.goormcoder.ieum.domain.Place;
 import com.goormcoder.ieum.domain.Plan;
 import com.goormcoder.ieum.dto.request.PlaceCreateDto;
+import com.goormcoder.ieum.dto.request.PlaceShareDto;
+import com.goormcoder.ieum.dto.response.PlaceFindDto;
 import com.goormcoder.ieum.exception.ErrorMessages;
 import com.goormcoder.ieum.repository.CategoryRepository;
 import com.goormcoder.ieum.repository.PlaceRepository;
@@ -16,7 +18,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
 
 @Service
@@ -38,12 +39,18 @@ public class PlaceService {
         Place place = placeRepository.save(Place.of(plan, member, null, null, dto.placeName(), dto.address(), category));
     }
 
-    public List<Place> findAllPlaces() {
-        return placeRepository.findAll();
+    @Transactional
+    public PlaceFindDto sharePlace(PlaceShareDto dto) {
+        // memberService.findById(memberId); - 검증 추가 예정
+        Place place = findPlaceById(dto.placeId());
+        place.marksActivatedAt();
+        Place savedPlace = placeRepository.save(place);
+
+        return PlaceFindDto.of(savedPlace);
     }
 
-    public Optional<Place> findPlaceById(Long id) {
-        return placeRepository.findById(id);
+    public List<Place> findAllPlaces() {
+        return placeRepository.findAll();
     }
 
     public Place updatePlace(Long id, Place updatedPlace) {
@@ -66,5 +73,10 @@ public class PlaceService {
     private Category findByCategoryId(Long categoryId) {
         return categoryRepository.findById(categoryId)
                 .orElseThrow(() -> new EntityNotFoundException(ErrorMessages.CATEGORY_NOT_FOUND.getMessage()));
+    }
+
+    private Place findPlaceById(Long placeId) {
+        return placeRepository.findById(placeId)
+                .orElseThrow(() -> new EntityNotFoundException(ErrorMessages.PLACE_NOT_FOUND.getMessage()));
     }
 }

--- a/src/main/java/com/goormcoder/ieum/service/PlanService.java
+++ b/src/main/java/com/goormcoder/ieum/service/PlanService.java
@@ -1,13 +1,13 @@
 package com.goormcoder.ieum.service;
 
-import com.goormcoder.ieum.domain.*;
-import com.goormcoder.ieum.domain.enumeration.InviteAcceptance;
+import com.goormcoder.ieum.domain.Destination;
+import com.goormcoder.ieum.domain.Member;
+import com.goormcoder.ieum.domain.Plan;
+import com.goormcoder.ieum.domain.PlanMember;
 import com.goormcoder.ieum.dto.request.PlanCreateDto;
 import com.goormcoder.ieum.dto.response.DestinationFindDto;
-import com.goormcoder.ieum.exception.ConflictException;
 import com.goormcoder.ieum.exception.ErrorMessages;
 import com.goormcoder.ieum.repository.DestinationRepository;
-import com.goormcoder.ieum.repository.InviteRepository;
 import com.goormcoder.ieum.repository.PlanRepository;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
@@ -16,7 +16,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.UUID;
-import java.util.stream.Stream;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/com/goormcoder/ieum/service/PlanService.java
+++ b/src/main/java/com/goormcoder/ieum/service/PlanService.java
@@ -43,7 +43,7 @@ public class PlanService {
     
     public Plan findByPlanId(Long planId) {
         return planRepository.findById(planId)
-                .orElseThrow(() -> new EntityNotFoundException(ErrorMessages.MEMBER_NOT_FOUND.getMessage()));
+                .orElseThrow(() -> new EntityNotFoundException(ErrorMessages.PLAN_NOT_FOUND.getMessage()));
     }
 
 }

--- a/src/main/java/com/goormcoder/ieum/service/PlanService.java
+++ b/src/main/java/com/goormcoder/ieum/service/PlanService.java
@@ -40,5 +40,10 @@ public class PlanService {
         plan.addPlanMember(PlanMember.of(plan, member));
         planRepository.save(plan);
     }
+    
+    public Plan findByPlanId(Long planId) {
+        return planRepository.findById(planId)
+                .orElseThrow(() -> new EntityNotFoundException(ErrorMessages.MEMBER_NOT_FOUND.getMessage()));
+    }
 
 }


### PR DESCRIPTION
## 🚀 작업 내용
- 장소 추가 api 구현
- 장소 공유 api 구현

## 📝 참고 사항
- Plan Entity 변경
  - BaseEntity 적용
  - 시작일시(startedAt), 종료일시(endedAt), 공유일시(activatedAt), 카테고리(category) 필드 추가
  - 장소위치 필드명 변경(placeLocation → address)
- [WebSocket & STOMP] 실시간 장소 공유
  - Web Socket Connection URL - ws://localhost:8080/ws
  - [수신] Subscription Path - /sub/plans/{planId}
  - [송신] Send Destination - /pub/share-place
  - 사용자 검증 추가 예정

## 🖼️ 스크린샷
![image](https://github.com/user-attachments/assets/a06d6cc9-17e0-44f2-92ec-bdc4a6f494de)

![image](https://github.com/user-attachments/assets/d584af44-71a2-4003-baf5-01af1c39b08a)
