### PR TITLE
feat & refactor: 일정 삭제 구현 및 장소 공유 검증 추가

### DIFF
--- a/src/main/java/com/goormcoder/ieum/controller/PlaceController.java
+++ b/src/main/java/com/goormcoder/ieum/controller/PlaceController.java
@@ -46,14 +46,14 @@ public class PlaceController {
     }
 
     @GetMapping("/{placeId}")
-    @Operation(summary = "장소 조회", description = "장소를 조회합니다.")
+    @Operation(summary = "장소 조회", description = "장소를 조회합니다. 공유되지 않은 장소의 경우 방문일시가 응답에 포함되지 않습니다.")
     public ResponseEntity<PlaceFindDto> getPlace(@PathVariable Long planId, @PathVariable Long placeId) {
         UUID memberId = getMemberId();
         return ResponseEntity.status(HttpStatus.OK).body(placeService.getPlace(planId, placeId, memberId));
     }
 
     @GetMapping()
-    @Operation(summary = "장소 전체 조회", description = "사용자별 장소를 전체 조회합니다. 사용자가 공유한 장소는 조회되지 않습니다.")
+    @Operation(summary = "장소 전체 조회", description = "사용자별 장소를 전체 조회합니다. 사용자가 공유한 장소는 조회되지 않으며, 장소 방문일시는 응답에 포함되지 않습니다.")
     public ResponseEntity<List<PlaceFindDto>> getAllPlaces(@PathVariable Long planId) {
         UUID memberId = getMemberId();
         return ResponseEntity.status(HttpStatus.OK).body(placeService.getAllPlaces(planId, memberId));

--- a/src/main/java/com/goormcoder/ieum/controller/PlanController.java
+++ b/src/main/java/com/goormcoder/ieum/controller/PlanController.java
@@ -68,16 +68,24 @@ public class PlanController {
         List<PlanSortDto> plans = planService.listPlansByDestination(destinationName);
         return ResponseEntity.status(HttpStatus.OK).body(plans);
     }
-
-    private UUID getMemberId() {
-        return UUID.fromString(SecurityContextHolder.getContext().getAuthentication().getPrincipal().toString());
-    }
     
     @GetMapping("/sorted/{destinationName}/{start}/{end}")
     @Operation(summary = "특정 기간 동안의 지역별 일정 조회", description = "특정 기간 동안 특정 지역의 일정을 조회합니다.")
     public ResponseEntity<List<PlanSortDto>> getPlansByDestinationAndDateRange(@PathVariable DestinationName destinationName, @PathVariable LocalDateTime start, @PathVariable LocalDateTime end) {
         List<PlanSortDto> plans = planService.listPlansByDestinationAndDateRange(destinationName, start, end);
         return ResponseEntity.status(HttpStatus.OK).body(plans);
+    }
+
+    @DeleteMapping("/{planId}")
+    @Operation(summary = "일정 삭제", description = "일정을 삭제합니다.")
+    public ResponseEntity<String> deletePlan(@PathVariable Long planId) {
+        UUID memberId = getMemberId();
+        planService.deletePlan(planId, memberId);
+        return ResponseEntity.status(HttpStatus.OK).body("일정이 삭제되었습니다.");
+    }
+
+    private UUID getMemberId() {
+        return UUID.fromString(SecurityContextHolder.getContext().getAuthentication().getPrincipal().toString());
     }
 
 }

--- a/src/main/java/com/goormcoder/ieum/domain/Place.java
+++ b/src/main/java/com/goormcoder/ieum/domain/Place.java
@@ -71,8 +71,8 @@ public class Place extends BaseEntity {
         this.activatedAt = LocalDateTime.now();
     }
 
-    public boolean isActive() {
-        return this.activatedAt != null;
+    public boolean isActivated() {
+        return this.activatedAt == null;
     }
 
     public void marksStartedAt(LocalDateTime startedAt) {

--- a/src/main/java/com/goormcoder/ieum/dto/response/PlaceFindDto.java
+++ b/src/main/java/com/goormcoder/ieum/dto/response/PlaceFindDto.java
@@ -1,5 +1,6 @@
 package com.goormcoder.ieum.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.goormcoder.ieum.domain.Place;
 
 import java.time.LocalDateTime;
@@ -9,8 +10,12 @@ public record PlaceFindDto(
 
         String placeName,
         String address,
+
+        @JsonInclude(JsonInclude.Include.NON_NULL)
         LocalDateTime startedAt,
+        @JsonInclude(JsonInclude.Include.NON_NULL)
         LocalDateTime endedAt,
+        
         Long categoryId,
         String memberLoginId
 

--- a/src/main/java/com/goormcoder/ieum/exception/ErrorMessages.java
+++ b/src/main/java/com/goormcoder/ieum/exception/ErrorMessages.java
@@ -28,7 +28,8 @@ public enum ErrorMessages {
     // 409 CONFLICT
     INVITE_REQUEST_CONFLICT("이미 초대한 멤버입니다."),
     INVITE_RESPONSE_CONFLICT("이미 응답 또는 취소된 초대입니다."),
-    PLACE_CONFLICT("해당 장소는 이미 추가되었습니다.")
+    PLACE_CONFLICT("해당 장소는 이미 추가되었습니다."),
+    SHARED_PLACE_CONFLICT("해당 장소는 이미 공유되었습니다."),
 
     ;
 

--- a/src/main/java/com/goormcoder/ieum/exception/WebSocketExceptionHandler.java
+++ b/src/main/java/com/goormcoder/ieum/exception/WebSocketExceptionHandler.java
@@ -1,0 +1,16 @@
+package com.goormcoder.ieum.exception;
+
+import org.springframework.messaging.handler.annotation.MessageExceptionHandler;
+import org.springframework.messaging.handler.annotation.SendTo;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class WebSocketExceptionHandler {
+
+    @MessageExceptionHandler
+    @SendTo("/sub/errors")
+    public String handleException(Exception exception) {
+        return exception.getMessage();
+    }
+
+}

--- a/src/main/java/com/goormcoder/ieum/repository/PlaceRepository.java
+++ b/src/main/java/com/goormcoder/ieum/repository/PlaceRepository.java
@@ -25,6 +25,8 @@ public interface PlaceRepository extends JpaRepository<Place, Long> {
 
     List<Place> findByPlanAndActivatedAtIsNotNullAndDeletedAtIsNull(Plan plan);
 
+    Boolean existsByPlanAndPlaceNameAndActivatedAtIsNotNullAndDeletedAtIsNull(Plan plan, String placeName);
+
     @Query("SELECT p FROM Place p WHERE p.plan = :plan AND CAST(p.startedAt AS DATE) = :date AND p.startedAt IS NOT NULL AND p.activatedAt IS NOT NULL AND p.deletedAt IS NULL ORDER BY p.startedAt")
     List<Place> findByPlanAndDate(@Param("plan") Plan plan, @Param("date") LocalDate date);
 

--- a/src/main/java/com/goormcoder/ieum/repository/PlanRepository.java
+++ b/src/main/java/com/goormcoder/ieum/repository/PlanRepository.java
@@ -7,9 +7,12 @@ import org.springframework.stereotype.Repository;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface PlanRepository extends JpaRepository<Plan, Long> {
+
+    Optional<Plan> findByIdAndDeletedAtIsNull(Long id);
 
     // 최신순으로 모든 일정 조회
     List<Plan> findAllByOrderByStartedAtDesc();

--- a/src/main/java/com/goormcoder/ieum/service/PlaceService.java
+++ b/src/main/java/com/goormcoder/ieum/service/PlaceService.java
@@ -60,6 +60,8 @@ public class PlaceService {
         place.marksActivatedAt();
 
         Plan plan = planService.findByPlanId(dto.planId());
+        place.marksStartedAt(plan.getStartedAt());
+        place.marksEndedAt(plan.getEndedAt());
         plan.addPlace(place);
         planRepository.save(plan);
 

--- a/src/main/java/com/goormcoder/ieum/service/PlaceService.java
+++ b/src/main/java/com/goormcoder/ieum/service/PlaceService.java
@@ -125,7 +125,7 @@ public class PlaceService {
         validatePlaceVisitTimeUpdateDto(dto, plan);
 
         Place place = findPlaceById(placeId);
-        if(!place.isActive()) {
+        if(place.isActivated()) {
             throw new IllegalArgumentException(ErrorMessages.BAD_REQUEST_PLACE_NOT_ACTIVE.getMessage());
         }
 
@@ -182,7 +182,7 @@ public class PlaceService {
     }
 
     private void handleUnActivePlace(Place place, Member member) {
-        if(!place.isActive()) {
+        if(place.isActivated()) {
             if(!place.getMember().equals(member)) {
                 throw new ForbiddenException(ErrorMessages.FORBIDDEN_ACCESS);
             }

--- a/src/main/java/com/goormcoder/ieum/service/PlaceService.java
+++ b/src/main/java/com/goormcoder/ieum/service/PlaceService.java
@@ -57,9 +57,10 @@ public class PlaceService {
         // memberService.findById(memberId); - 검증 추가 예정
         // validatePlanMember(plan, member);
         Place place = findPlaceById(dto.placeId());
-        place.marksActivatedAt();
-
         Plan plan = planService.findByPlanId(dto.planId());
+        validateSharedPlace(plan, place);
+
+        place.marksActivatedAt();
         place.marksStartedAt(plan.getStartedAt());
         place.marksEndedAt(plan.getEndedAt());
         plan.addPlace(place);
@@ -198,6 +199,12 @@ public class PlaceService {
         }
 
         return plan.getNthDayDate(day);
+    }
+
+    private void validateSharedPlace(Plan plan, Place place) {
+        if(placeRepository.existsByPlanAndPlaceNameAndActivatedAtIsNotNullAndDeletedAtIsNull(plan, place.getPlaceName())) {
+            throw new ConflictException(ErrorMessages.SHARED_PLACE_CONFLICT);
+        }
     }
 
 }

--- a/src/main/java/com/goormcoder/ieum/service/PlanService.java
+++ b/src/main/java/com/goormcoder/ieum/service/PlanService.java
@@ -80,8 +80,17 @@ public class PlanService {
         return PlanSortDto.listOf(plans);
     }
 
+    @Transactional
+    public void deletePlan(Long planId, UUID memberId) {
+        Member member = memberService.findById(memberId);
+        Plan plan = findByPlanId(planId);
+        validatePlanMember(plan, member);
+        plan.markAsDeleted();
+        planRepository.save(plan);
+    }
+
     public Plan findByPlanId(Long planId) {
-        return planRepository.findById(planId)
+        return planRepository.findByIdAndDeletedAtIsNull(planId)
                 .orElseThrow(() -> new EntityNotFoundException(ErrorMessages.PLAN_NOT_FOUND.getMessage()));
     }
 


### PR DESCRIPTION
## 🚀 작업 내용
- 일정 삭제 api 구현
- 장소 공유 검증 추가
- WebSocket 예외 처리 로직 추가

## 📝 참고 사항
- 장소 공유 시, 장소 방문일시 일정 시작일시와 종료일시로 초기화
- 장소 중복 공유 불가
- [WebSocket & STOMP] 실시간 장소 공유
  - Web Socket Connection URL - ws://localhost:8080/ws
  - [수신] Subscription Path - /sub/plans/{planId}
  - [에러 수신] Subscription Path - /sub/errors
  - [송신] Send Destination - /pub/share-place
  - 사용자 검증 추가 예정

## 🖼️ 스크린샷
![image](https://github.com/user-attachments/assets/fd12d3cf-f567-412e-9861-7b54ff9d7d37)
