### PR TITLE
feat: 사용자 엔티티에 이메일 필드 추가

### DIFF
--- a/src/main/java/com/goormcoder/ieum/controller/AuthController.java
+++ b/src/main/java/com/goormcoder/ieum/controller/AuthController.java
@@ -13,6 +13,7 @@ import com.goormcoder.ieum.service.MemberService;
 import com.goormcoder.ieum.service.RefreshTokenService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -39,7 +40,7 @@ public class AuthController {
 
     @Operation(summary = "자체 회원 가입")
     @PostMapping("/join")
-    public ResponseEntity<MemberFindDto> create(@RequestBody MemberCreateDto createDto) {
+    public ResponseEntity<MemberFindDto> create(@Valid @RequestBody MemberCreateDto createDto) {
         Member member = memberService.createByLoginId(createDto);
         return ResponseEntity.ok(MemberFindDto.of(member));
     }

--- a/src/main/java/com/goormcoder/ieum/domain/Member.java
+++ b/src/main/java/com/goormcoder/ieum/domain/Member.java
@@ -7,6 +7,7 @@ import jakarta.persistence.EntityListeners;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.validation.constraints.Email;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Collection;
@@ -36,6 +37,7 @@ public class Member {
     private MemberRole role;
     private Gender gender;
     private LocalDate birth;
+    private String email;
 
     private String loginId;
     private String password;
@@ -48,11 +50,12 @@ public class Member {
     private LocalDateTime deletedAt;
 
     @Builder
-    public Member(String name, MemberRole role, Gender gender, LocalDate birth, String loginId, String password, String oauthType, String oauthId) {
+    public Member(String name, MemberRole role, Gender gender, LocalDate birth, String email, String loginId, String password, String oauthType, String oauthId) {
         this.name = name;
         this.role = role;
         this.gender = gender;
         this.birth = birth;
+        this.email = email;
         this.loginId = loginId;
         this.password = password;
         this.oauthType = oauthType;
@@ -71,13 +74,12 @@ public class Member {
         this.birth = birth;
     }
 
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
     public void setPassword(String password) {
         this.password = password;
     }
 
-
-    //수정필요
-    public String getEmail() {
-        return "email";
-    }
 }

--- a/src/main/java/com/goormcoder/ieum/dto/request/MemberCreateDto.java
+++ b/src/main/java/com/goormcoder/ieum/dto/request/MemberCreateDto.java
@@ -1,12 +1,15 @@
 package com.goormcoder.ieum.dto.request;
 
 import com.goormcoder.ieum.domain.enumeration.Gender;
+import jakarta.validation.constraints.Email;
 import java.time.LocalDate;
 
 public record MemberCreateDto(
         String name,
         Gender gender,
         LocalDate birth,
+        @Email
+        String email,
         String loginId,
         String password
 ) {

--- a/src/main/java/com/goormcoder/ieum/dto/request/MemberUpdateDto.java
+++ b/src/main/java/com/goormcoder/ieum/dto/request/MemberUpdateDto.java
@@ -1,12 +1,15 @@
 package com.goormcoder.ieum.dto.request;
 
 import com.goormcoder.ieum.domain.enumeration.Gender;
+import jakarta.validation.constraints.Email;
 import java.time.LocalDate;
 
 public record MemberUpdateDto (
         String name,
         Gender gender,
-        LocalDate birth
+        LocalDate birth,
+        @Email
+        String email
 ) {
 
 }

--- a/src/main/java/com/goormcoder/ieum/dto/response/MemberFindDto.java
+++ b/src/main/java/com/goormcoder/ieum/dto/response/MemberFindDto.java
@@ -14,6 +14,7 @@ public record MemberFindDto(
         MemberRole role,
         Gender gender,
         LocalDate birth,
+        String email,
 
         String loginId,
         String oauthType,
@@ -30,6 +31,7 @@ public record MemberFindDto(
                 member.getRole(),
                 member.getGender(),
                 member.getBirth(),
+                member.getEmail(),
 
                 member.getLoginId(),
                 member.getOauthType(),

--- a/src/main/java/com/goormcoder/ieum/service/KakaoOauthService.java
+++ b/src/main/java/com/goormcoder/ieum/service/KakaoOauthService.java
@@ -6,6 +6,7 @@ import com.goormcoder.ieum.dto.response.OAuthUserInfoDto;
 import java.time.LocalDate;
 import java.util.Collections;
 import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
@@ -17,6 +18,7 @@ import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
 
+@Slf4j
 @Service
 public class KakaoOauthService {
 
@@ -37,6 +39,9 @@ public class KakaoOauthService {
         Map attributes = getUserInfoAttributes(accessToken);
         Map kakaoAccount = (Map) attributes.get("kakao_account");
         Map profile = (Map) kakaoAccount.get("profile");
+
+        log.info("attributes: {}", attributes);
+
         return OAuthUserInfoDto.builder()
                 .registrationId("kakao")
                 .id(attributes.get("id").toString())

--- a/src/main/java/com/goormcoder/ieum/service/MemberService.java
+++ b/src/main/java/com/goormcoder/ieum/service/MemberService.java
@@ -56,6 +56,7 @@ public class MemberService {
                 .role(MemberRole.USER)
                 .gender(oAuthUserInfoDto.gender())
                 .birth(oAuthUserInfoDto.birth())
+                .email(oAuthUserInfoDto.email())
                 .loginId(null)
                 .password(null)
                 .build();
@@ -93,6 +94,7 @@ public class MemberService {
                 .role(MemberRole.USER)
                 .gender(createDto.gender())
                 .birth(createDto.birth())
+                .email(createDto.email())
                 .loginId(createDto.loginId())
                 .password(passwordEncoder.encode(createDto.password()))
                 .oauthType(null)
@@ -107,6 +109,7 @@ public class MemberService {
         member.setName(updateDto.name());
         member.setGender(updateDto.gender());
         member.setBirth(updateDto.birth());
+        member.setEmail(updateDto.email());
         memberRepository.save(member);
         return member;
     }


### PR DESCRIPTION
## 🚀 작업 내용
- 사용자 엔티티에 이메일 필드 추가

## 📝 참고 사항
- 자체 회원가입 시 이메일 기입 추가
- 사용자 정보 수정 시 이메일 기입 추가
- 사용자 조회 시 이메일 또한 조회

## 🖼️ 스크린샷
