### PR TITLE
fix : 멤버 검색에 @AuthenticationPrincipal 적용

### DIFF
--- a/src/main/java/com/goormcoder/ieum/controller/MemberController.java
+++ b/src/main/java/com/goormcoder/ieum/controller/MemberController.java
@@ -4,6 +4,7 @@ import com.goormcoder.ieum.domain.Member;
 import com.goormcoder.ieum.dto.response.MemberFindAllDto;
 import com.goormcoder.ieum.dto.response.MemberFindDto;
 import com.goormcoder.ieum.jwt.JwtProvider;
+import com.goormcoder.ieum.security.CustomUserDetails;
 import com.goormcoder.ieum.service.MemberService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -13,6 +14,7 @@ import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -36,9 +38,9 @@ public class MemberController {
 
     @Operation(summary = "회원 검색", description = "검색 키워드로 회원을 검색합니다. (본인 제외)")
     @GetMapping("/search/{keyword}")
-    public ResponseEntity<List<MemberFindAllDto>> getMember(@PathVariable String keyword) {
-        UUID memberId = UUID.fromString(SecurityContextHolder.getContext().getAuthentication().getPrincipal().toString());
-        return ResponseEntity.status(HttpStatus.OK).body(memberService.getAllMembersByLoginIdContainingAndIdIsNot(keyword, memberId));
+    public ResponseEntity<List<MemberFindAllDto>> getMember(@AuthenticationPrincipal CustomUserDetails userDetails, @PathVariable String keyword) {
+        Member member = userDetails.getMember();
+        return ResponseEntity.status(HttpStatus.OK).body(memberService.getAllMembersByLoginIdContainingAndIdIsNot(keyword, member));
     }
 
 }

--- a/src/main/java/com/goormcoder/ieum/service/MemberService.java
+++ b/src/main/java/com/goormcoder/ieum/service/MemberService.java
@@ -74,8 +74,8 @@ public class MemberService {
                 .orElseThrow(EntityNotFoundException::new);
     }
 
-    public List<MemberFindAllDto> getAllMembersByLoginIdContainingAndIdIsNot(String keyword, UUID memberId) {
-        return MemberFindAllDto.listOf(memberRepository.findAllByLoginIdContainingAndIdIsNot(keyword, memberId));
+    public List<MemberFindAllDto> getAllMembersByLoginIdContainingAndIdIsNot(String keyword, Member member) {
+        return MemberFindAllDto.listOf(memberRepository.findAllByLoginIdContainingAndIdIsNot(keyword, member.getId()));
     }
 
     public Member findByLoginIdAndPassword(String loginId, String password) {


### PR DESCRIPTION
## 🚀 작업 내용
- MemberController의 키워드 검색에 @AuthenticationPrincipal 적용
- MemberService의 키워드 검색 메서드 매개변수 수정

## 📝 참고 사항

## 🖼️ 스크린샷
![image](https://github.com/user-attachments/assets/4302e451-f8cc-415f-a42c-746cda9dc79c)
![image](https://github.com/user-attachments/assets/ef78a878-0b5a-4991-8043-f026ad4a79f5)
